### PR TITLE
Add optional support for rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,14 @@ keywords = ["dataverse", "powerplatform", "dynamics"]
 categories = ["api-bindings"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["native-tls"]
+rustls = ["reqwest/rustls", "reqwest/rustls-tls"]
+native-tls = ["reqwest/default-tls"]
 
 [dependencies]
 chrono = "0.4.19"
-reqwest = "0.11.10"
+reqwest = { version = "0.11", default-features = false }
 tokio = { version = "1.18", features = ["full"] }
 lazy_static = "1.4"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Hi, thanks for making this crate! I've added optional support for using rustls instead of openssl to make it easier to cross-compile to e.g. linux-musl